### PR TITLE
Fixing error obscurity and an issue with the paths

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -40,9 +40,6 @@ module.exports = function(grunt) {
       child.stdout.pipe(process.stdout);
       byline(child.stderr).on('data', function(line) {
         var err = line.toString();
-        if (err.indexOf('Error:') > -1) {
-          err = err.match(/Error:\s*(.*?)\n/)[1];
-        }
 
         done(err);
       });

--- a/tasks/nightwatch.js
+++ b/tasks/nightwatch.js
@@ -106,8 +106,6 @@ module.exports = function(grunt) {
         $.verbose.ok('Target custom JSON-file: ' + file);
         $.mergeVars(settings, _.pick(data, settings_opts));
         $.mergeVars(options, _.pick(data, fake_opts));
-
-        $.expandPaths(file, settings, paths);
       }
     });
 


### PR DESCRIPTION
The error issue had us banging our heads into the desk trying to track down what was really wrong, so this will be a little better for the error logging.

The issue with the paths was interesting. I'm not sure what the `expandPaths` does, but it was really munging our paths. For example the config value of `_tests/ui/tests` was being converted to `_tests/ui/tests/ui/tests`.
